### PR TITLE
Scope todo cache invalidation to authenticated user

### DIFF
--- a/src/routes/api/v1/todos/index.ts
+++ b/src/routes/api/v1/todos/index.ts
@@ -203,7 +203,7 @@ export default async function (fastify: TypedFastifyInstance) {
           .values({ title, userId: permissionResult.session.user.id })
           .returning();
 
-        await fastify.cache.delByPrefix("todos:");
+        await fastify.cache.delByPrefix(`todos:|userId:${permissionResult.session.user.id}|`);
 
         return reply.send(addedTodo[0]);
       } catch (error) {
@@ -261,7 +261,7 @@ export default async function (fastify: TypedFastifyInstance) {
           return reply.code(404).send({ error: "Request not completed." });
         }
 
-        await fastify.cache.delByPrefix("todos:");
+        await fastify.cache.delByPrefix(`todos:|userId:${permissionResult.session.user.id}|`);
 
         return reply.send({
           message: `${deletedTodos.length} item/s deleted successfully`,
@@ -362,7 +362,7 @@ export default async function (fastify: TypedFastifyInstance) {
           });
         }
 
-        await fastify.cache.delByPrefix("todos:");
+        await fastify.cache.delByPrefix(`todos:|userId:${permissionResult.session.user.id}|`);
 
         return reply.send({
           message: `${updatedTodos.length} item/s updated successfully`,


### PR DESCRIPTION
### Motivation
- Cache keys for todos were made user-scoped via `buildTodosCacheKey`, so invalidation must target only the current user's keys to avoid evicting other users' cached pages.

### Description
- Updated cache invalidation in `src/routes/api/v1/todos/index.ts` for the mutation routes `POST /add`, `DELETE /api/v1/todos` and `PUT /update` to call `await fastify.cache.delByPrefix(`todos:|userId:${permissionResult.session.user.id}|`)` instead of the global `delByPrefix("todos:")`, which exactly matches the prefix produced by `buildTodosCacheKey`.

### Testing
- Ran `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d63e536f1883329fea3145c8c846cf)