### PR TITLE
fix(compose): improve dev/prod startup reliability

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -14,7 +14,7 @@ services:
       target: development
     container_name: fastify-drizzle-app-dev
     ports:
-      - '${APP_PORT}:3006' # API server
+      - '${APP_PORT:-3006}:3006' # API server
       # - '${DEBUG_PORT}:9229' # Node.js debugger
     environment:
       NODE_ENV: development
@@ -23,14 +23,14 @@ services:
       POSTGRES_PORT: 5432
       POSTGRES_DB: '${POSTGRES_DB:-fastifydb}'
       POSTGRES_USER: '${POSTGRES_USER:-postgres}'
-      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-postgres}'
       REDIS_HOST: '${REDIS_HOST}'
       REDIS_PORT: '${REDIS_PORT:-6379}'
       REDIS_USERNAME: '${REDIS_USERNAME}'
       REDIS_PASSWORD: '${REDIS_PASSWORD}'
       ALLOWED_ORIGINS: '${ALLOWED_ORIGINS}'
     volumes:
-      - ./src:/app/src:ro,Z
+      - ./src:/app/src:ro
       # - ./package.json:/app/package.json:Z
     depends_on:
       db:
@@ -61,7 +61,7 @@ services:
       target: production
     container_name: fastify-drizzle-app-prod
     ports:
-      - '${PROD_PORT}:3006'
+      - '${PROD_PORT:-3006}:3006'
     environment:
       NODE_ENV: production
       POSTGRES_HOST: db
@@ -101,16 +101,16 @@ services:
     image: postgres:latest
     container_name: fastify-drizzle-db
     environment:
-      POSTGRES_DB: '${POSTGRES_DB}'
-      POSTGRES_USER: '${POSTGRES_USER}'
-      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
+      POSTGRES_DB: '${POSTGRES_DB:-fastifydb}'
+      POSTGRES_USER: '${POSTGRES_USER:-postgres}'
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD:-postgres}'
       TZ: Asia/Manila
       PGTZ: Asia/Manila
       PGDATA: /var/lib/postgresql/data
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - '${DB_PORT}:5432'
+      - '${DB_PORT:-5432}:5432'
     restart: unless-stopped
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
@@ -128,14 +128,12 @@ services:
     image: redis:7-alpine
     container_name: fastify-drizzle-redis
     restart: unless-stopped
-    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
     volumes:
-      - ./redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
       - redis_data:/data
     ports:
       - "${REDIS_PORT:-6379}:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "--user", "${REDIS_USERNAME}", "--pass", "${REDIS_PASSWORD}", "ping"]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
### Motivation
- The Compose file had runtime fragility when `.env` values were missing which could prevent services from starting.
- Redis was configured to load a local `./redis/redis.conf` that does not exist in the repository, causing startup failures.
- Healthchecks and mounts were overly specific (auth flags in Redis healthcheck and SELinux `:Z` mount) which reduce cross-platform compatibility.

### Description
- Added safe default fallbacks for host port mappings `APP_PORT`, `PROD_PORT`, and `DB_PORT` using `${VAR:-default}` to allow Compose to start when env vars are absent.
- Added default values for PostgreSQL env vars in `db` and the dev service (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`) to avoid empty values breaking DB initialization.
- Removed the Redis custom command and the non-existent `./redis/redis.conf` bind mount so the official Redis image uses its default configuration.
- Simplified the Redis healthcheck to `redis-cli ping` to avoid requiring ACL username/password flags and removed the SELinux-specific `:Z` suffix from the dev source mount for better portability.

### Testing
- Ran `npm run typecheck` and TypeScript type checking completed successfully.
- Attempted to run `docker compose config` validation but the Docker CLI is not available in this environment so the Compose validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16f3e0074c8332ae534c2d3896d1b3)