### PR TITLE
Fix user accounts cursor ID pagination direction

### DIFF
--- a/src/routes/api/v1/user/index.ts
+++ b/src/routes/api/v1/user/index.ts
@@ -272,7 +272,9 @@ export default async function (fastify: TypedFastifyInstance) {
                         : gt(user.updatedAt, cursor.updatedAt),
                       and(
                         eq(user.updatedAt, cursor.updatedAt),
-                        lt(user.id, cursor.id),
+                        orderBy === "desc"
+                          ? lt(user.id, cursor.id)
+                          : gt(user.id, cursor.id),
                       ),
                     )
                   : undefined,


### PR DESCRIPTION
### Motivation
- Ensure cursor-based pagination in `GET /api/v1/user/accounts` compares the secondary `user.id` in the same direction as the route `orderBy` so paging is correct for both `asc` and `desc`.

### Description
- Updated the cursor predicate in `src/routes/api/v1/user/index.ts` to use `orderBy === "desc" ? lt(user.id, cursor.id) : gt(user.id, cursor.id)` instead of a static `lt(user.id, cursor.id)`, keeping the `updatedAt` and `id` comparisons consistent with the route's `.orderBy(...)` clause.

### Testing
- Ran `npm run typecheck` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19603248ec83329bac01264779180d)