### PR TITLE
Limit user accounts query projection

### DIFF
--- a/src/routes/api/v1/user/index.ts
+++ b/src/routes/api/v1/user/index.ts
@@ -290,7 +290,18 @@ export default async function (fastify: TypedFastifyInstance) {
             const pageUserIds = pageUserRows.map((row) => row.id);
 
             const usersCached = await db
-              .select()
+              .select({
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                image: user.image,
+                emailVerified: user.emailVerified,
+                createdAt: user.createdAt,
+                updatedAt: user.updatedAt,
+                roleId: user.roleId,
+                roleName: role.name,
+                permission: rolePermission.permission,
+              })
               .from(user)
               .leftJoin(role, eq(user.roleId, role.id))
               .leftJoin(rolePermission, eq(rolePermission.roleId, role.id))
@@ -303,13 +314,22 @@ export default async function (fastify: TypedFastifyInstance) {
             const map = new Map<string, UserAccountsNodes>();
 
             for (const row of usersCached) {
-              const uid = row.user.id;
-              const perm = row.role_permission?.permission ?? null;
+              const uid = row.id;
+              const perm = row.permission ?? null;
 
               if (!map.has(uid)) {
                 map.set(uid, {
-                  user: row.user,
-                  role: row.role?.name ?? null,
+                  user: {
+                    id: row.id,
+                    name: row.name,
+                    email: row.email,
+                    image: row.image,
+                    emailVerified: row.emailVerified,
+                    createdAt: row.createdAt,
+                    updatedAt: row.updatedAt,
+                    roleId: row.roleId,
+                  },
+                  role: row.roleName ?? null,
                   permissions: perm ? [perm] : [],
                 });
               } else if (perm) {


### PR DESCRIPTION
### Motivation
- Restrict the data returned by the `GET /api/v1/user/accounts` handler to only the intended response fields to avoid leaking extra role/permission metadata and reduce payload size. 
- Preserve the existing response contract of `UserAccountsNodes` (`user`, `role`, `permissions`) while sourcing values from a safe, explicit projection.

### Description
- Replace the broad `db.select()` with an explicit projection selecting only user fields `id`, `name`, `email`, `image`, `emailVerified`, `createdAt`, `updatedAt`, `roleId`, plus `role.name` as `roleName` and `role_permission.permission` as `permission`.
- Update the row-mapping loop to read from the projected shape (`row.id`, `row.name`, `row.email`, etc.) and reconstruct the `user` object and `role`/`permissions` into the existing `UserAccountsNodes` format.
- Intentionally omit role `description`, role `isSystem` flag, role timestamps, and any role-permission `id` or timestamps from the selected data.

### Testing
- Ran `npm run typecheck` which completed successfully.
- Ran `npm run format` to apply formatting which completed successfully.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196355cd6c8332ae29212f8b2dc16b)